### PR TITLE
Fix initialization order

### DIFF
--- a/RobinTheEngine/src/RobinTheEngine/JobSystem/JobSystem.cpp
+++ b/RobinTheEngine/src/RobinTheEngine/JobSystem/JobSystem.cpp
@@ -1,4 +1,0 @@
-#include "rtepch.h"
-#include "JobSystem.h"
-
-RTE::JobSystem RTE::JobSystem::js;

--- a/RobinTheEngine/src/RobinTheEngine/JobSystem/JobSystem.h
+++ b/RobinTheEngine/src/RobinTheEngine/JobSystem/JobSystem.h
@@ -114,12 +114,12 @@ namespace RTE {
         }
 
         static JobSystem& GetJobSystem() {
+            static JobSystem js;
             return js;
         }
 
     private:
         vgjs::JobSystem jobSystem;
-        static JobSystem js;
         JobSystem() : jobSystem(vgjs::thread_count_t(std::thread::hardware_concurrency()), vgjs::thread_index_t(1)) {
             SetThreadAffinityMask(GetCurrentThread(), 0);
         };


### PR DESCRIPTION
Move JobSystem initialization to GetJobSystem method to avoid static order initialization problems with logger